### PR TITLE
Use rxjs from to convert promise to observable

### DIFF
--- a/lib/promise-to-observable.ts
+++ b/lib/promise-to-observable.ts
@@ -1,16 +1,7 @@
 import {AxiosPromise, AxiosResponse} from "axios";
-import {Observable, Observer} from "rxjs/index";
+import {from, Observer} from "rxjs/index";
 import {AxiosObservable} from "./axios-observable.interface";
 
 export const promiseToObservable = <T = any>(promise: AxiosPromise<T>): AxiosObservable<T> => {
-  return Observable.create((observer: Observer<AxiosResponse<T>>) => {
-    return promise
-      .then((response: AxiosResponse<T>) => {
-        observer.next(response);
-        observer.complete();
-      })
-      .catch(err => {
-        observer.error(err);
-      })
-  })
+  return from(promise);
 };


### PR DESCRIPTION
hi @zhaosiyang  -- we're using your library and we noticed that we're getting error messages any time that we get a non-200 HTTP response

```
(node:36524) UnhandledPromiseRejectionWarning: TypeError: this._parentSubscription.unsubscribe is not a function
    at MergeMapSubscriber.Subscriber._unsubscribeParentSubscription 
(node:36524) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async funct
ion without a catch block, or by rejecting a promise which was not handled with .catch().
``` 

I think the problem comes from manually trying to create an observable from a promise. According to [this SO post](https://stackoverflow.com/questions/52337488/typeerror-this-parentsubscription-unsubscribe-is-not-a-function), `Observable.create()` does not handle promises. So I think it would be better to use the rxjs `from` method. 