### PR TITLE
remove 'static' on interceptors

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -9,7 +9,7 @@ class Axios {
   }
 
   static defaults: AxiosRequestConfig = axios.defaults;
-  static interceptors: {
+  interceptors: {
     request: AxiosInterceptorManager<AxiosRequestConfig>;
     response: AxiosInterceptorManager<AxiosResponse>;
   } = axios.interceptors;


### PR DESCRIPTION
slight change: .interceptors is not a static property in the original library: 
[https://github.com/axios/axios/blob/75c8b3f146aaa8a71f7dca0263686fb1799f8f31/index.d.ts](url)

Thanks for the wrapper - it's really useful!