### PR TITLE
fix: Property 'subscribe' does not exist on type 'AxiosObservable'

### DIFF
--- a/lib/axios-observable.interface.ts
+++ b/lib/axios-observable.interface.ts
@@ -1,5 +1,4 @@
 import {AxiosResponse} from 'axios';
 import {Observable} from 'rxjs';
 
-export interface AxiosObservable<T> extends Observable<AxiosResponse<T>> {
-}
+export type  AxiosObservable<T> = Observable<AxiosResponse<T>>


### PR DESCRIPTION
This type failed to compile in Typescript4.1.6